### PR TITLE
Fix `make install` on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ all:
 
 .PHONY: install
 install:
-	install -Dm755 bin/tt -t $(DESTDIR)$(PREFIX)/bin
-	install -Dm644 tt.1.gz -t $(DESTDIR)$(PREFIX)/share/man/man1
+	install -d $(DESTDIR)$(PREFIX)/{bin,share/man/man1}
+	install -m755 bin/tt $(DESTDIR)$(PREFIX)/bin
+	install -m644 tt.1.gz $(DESTDIR)$(PREFIX)/share/man/man1
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
`install -D` is not available on macOS, so we create the directories with `install -d` before installing.
`instal -t` is also not present but turns out we didn't really need it as it's only useful if you want to specify the destination directory before the source, so I just removed the `t` flag.

Really, this is my own fault, when changing the `Makefile` I didn't take other OSs into account, wrongly assuming the coreutils would work the same.

Fixes #7 