### PR TITLE
Marking `go` as a dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ sudo curl -o /usr/share/man/man1/tt.1.gz -L https://github.com/lemnos/tt/release
 ## OSX
 
 ```
+mkdir -p /usr/local/bin /usr/local/share/man/man1 # Usually created by brew
+
 sudo curl -L https://github.com/lemnos/tt/releases/download/v0.4.2/tt-osx -o /usr/local/bin/tt && sudo chmod +x /usr/local/bin/tt
 sudo curl -o /usr/local/share/man/man1/tt.1.gz -L https://github.com/lemnos/tt/releases/download/v0.4.2/tt.1.gz
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ sudo rm /usr/local/bin/tt /usr/share/man/man1/tt.1.gz
 ## From source
 
 ```
+# dependencies
+sudo apt install golang
+
+# clone and make
 git clone https://github.com/lemnos/tt
 cd tt
 make && sudo make install

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo rm /usr/local/bin/tt /usr/share/man/man1/tt.1.gz
 ## From source
 
 ```
-# dependencies
+# debian dependencies
 sudo apt install golang
 
 # clone and make


### PR DESCRIPTION
Makes it easier to follow along the readme 