### PR TITLE
adding a new test in a code style typing

### DIFF
--- a/man.md
+++ b/man.md
@@ -184,7 +184,7 @@ curl https://api.quotable.io/quotes|\
 Starts a new test in a code style typing.
 
 ```bash
-curl -LsS https://raw.githubusercontent.com/lemnos/tt/master/src/tt.go | grep -v '^//\|^$' | head -n 20 | tt -raw
+curl -LsS https://raw.githubusercontent.com/lemnos/tt/master/src/tt.go | head -n 20 | tt -raw
 ```
 
 # PATHS

--- a/man.md
+++ b/man.md
@@ -184,7 +184,7 @@ curl https://api.quotable.io/quotes|\
 Starts a new test in a code style typing.
 
 ```bash
-curl -LsS https://raw.githubusercontent.com/lemnos/tt/master/src/tt.go | head -n 20 | tt -raw
+curl -LsS https://raw.githubusercontent.com/lemnos/tt/master/src/tt.go | head -n 20 | tt -noskip -raw
 ```
 
 # PATHS

--- a/man.md
+++ b/man.md
@@ -181,6 +181,12 @@ curl https://api.quotable.io/quotes|\
     tt -quotes - -norreport -csv
 ```
 
+Starts a new test in a code style typing.
+
+```bash
+curl -LsS https://raw.githubusercontent.com/lemnos/tt/master/src/tt.go | grep -v '^//\|^$' | head -n 20 | tt -raw
+```
+
 # PATHS
 
   Some options like **-words** and **-theme** accept a path. If the given path does


### PR DESCRIPTION
hey @lemnos thanks for this typing on terminal idea.

I was thinking about using this `cli` to practice more in a *real case* scenario which we developers are more used to do in a daily basis.

It would be fantastic to maybe bring the possibility of replicate code "quotes" as a test to practice our typing speed. 

As an example I usually uses [typing.io](https://typing.io) to practice but due to the fact we should always go and open the browser, isnt so simple as do it at our own terminal.

this one is a new test in a code style typing to the `man.md` file. the new test is added to the section on paths and is written in the bash language.

unfortunately there is some bugs to interact with words as we complete typing.

please try it yourself with the following example.

```bash
curl -LsS https://raw.githubusercontent.com/lemnos/tt/master/src/tt.go |  head -n 20 | tt -noskip -raw
```
<img width="901" alt="Screenshot 2023-01-15 at 22 26 49" src="https://user-images.githubusercontent.com/33763843/212568174-4c5853ad-de69-4f2c-86b8-beeb206348f5.png">

let me know if it makes senses to proceed with this feature at this repo our I should create my own version of it.

see yo
