### PR TITLE
Adds more key options for better test flow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ options.
 ## Keys
 
 - Pressing `escape` at any point restarts the test.
-- In the report page `escape`, `enter`, and `space` will close the page and load the next test. If flag `-oneshot` is enabled, the program terminates.
+- `escape`, `enter`, or `space` will close the report page. If `-oneshot` is not set, the next test is loaded.
 - `C-c` exits the test.
 - `right` moves to the next test.
 - `left` moves to the previous test.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ options.
 ## Keys
 
 - Pressing `escape` at any point restarts the test.
+- In the report page `escape`, `enter`, and `space` will close the page and load the next test. If flag `-oneshot` is enabled, the program terminates.
 - `C-c` exits the test.
 - `right` moves to the next test.
 - `left` moves to the previous test.

--- a/src/tt.go
+++ b/src/tt.go
@@ -110,7 +110,9 @@ func showReport(scr tcell.Screen, cpm, wpm int, accuracy float64, attribution st
 	scr.Show()
 
 	for {
-		if key, ok := scr.PollEvent().(*tcell.EventKey); ok && key.Key() == tcell.KeyEscape {
+		key, ok := scr.PollEvent().(*tcell.EventKey)
+	
+		if ok && (key.Key() == tcell.KeyEscape || key.Key() == tcell.KeyEnter || key.Rune() == 32) {
 			return
 		} else if ok && key.Key() == tcell.KeyCtrlC {
 			exit(1)

--- a/src/tt.go
+++ b/src/tt.go
@@ -86,7 +86,7 @@ func exit(rc int) {
 	os.Exit(rc)
 }
 
-func showReport(scr tcell.Screen, cpm, wpm int, accuracy float64, attribution string, mistakes []mistake) {
+func showReport(scr tcell.Screen, cpm, wpm int, accuracy float64, attribution string, mistakes []mistake, titleStyle tcell.Style) {
 	mistakeStr := ""
 	if attribution != "" {
 		attribution = "\n\nAttribution: " + attribution
@@ -106,12 +106,13 @@ func showReport(scr tcell.Screen, cpm, wpm int, accuracy float64, attribution st
 
 	scr.Clear()
 	drawStringAtCenter(scr, report, tcell.StyleDefault)
+	drawStringAsTitle(scr, "Press ESC, SPACE, or ENTER to continue.", titleStyle)
 	scr.HideCursor()
 	scr.Show()
 
 	for {
 		key, ok := scr.PollEvent().(*tcell.EventKey)
-	
+
 		if ok && (key.Key() == tcell.KeyEscape || key.Key() == tcell.KeyEnter || key.Rune() == 32) {
 			return
 		} else if ok && key.Key() == tcell.KeyCtrlC {
@@ -385,7 +386,7 @@ func main() {
 	typer.ShowWpm = showWpm
 
 	if timeout != -1 {
-		timeout *= 1E9
+		timeout *= 1e9
 	}
 
 	var tests [][]segment
@@ -417,7 +418,7 @@ func main() {
 				idx--
 			}
 		case TyperComplete:
-			cpm := int(float64(ncorrect) / (float64(t) / 60E9))
+			cpm := int(float64(ncorrect) / (float64(t) / 60e9))
 			wpm := cpm / 5
 			accuracy := float64(ncorrect) / float64(nerrs+ncorrect) * 100
 
@@ -427,7 +428,7 @@ func main() {
 				if len(tests[idx]) == 1 {
 					attribution = tests[idx][0].Attribution
 				}
-				showReport(scr, cpm, wpm, accuracy, attribution, mistakes)
+				showReport(scr, cpm, wpm, accuracy, attribution, mistakes, typer.nextWordStyle)
 			}
 			if oneShotMode {
 				exit(0)

--- a/src/util.go
+++ b/src/util.go
@@ -147,6 +147,16 @@ func drawStringAtCenter(scr tcell.Screen, s string, style tcell.Style) {
 	drawString(scr, x, y, s, -1, style)
 }
 
+func drawStringAsTitle(scr tcell.Screen, s string, style tcell.Style) {
+	nc, nr := calcStringDimensions(s)
+	sw, sh := scr.Size()
+
+	x := (sw - nc) / 2
+	y := sh - (sh - nr)
+
+	drawString(scr, x, y, s, -1, style)
+}
+
 func calcStringDimensions(s string) (nc, nr int) {
 	if s == "" {
 		return 0, 0


### PR DESCRIPTION
Using keys such as `space` and `return` is normal practice to move forward from info pages. This pull request adds those options and instructions for clarity (also, it looks cool).

The key events captured after the test finishes are discarded to avoid skipping the report too early.