### PR TITLE
Disables rerender when not interacting

### DIFF
--- a/src/typer.go
+++ b/src/typer.go
@@ -313,6 +313,9 @@ func (t *typer) start(s string, timeLimit time.Duration, startImmediately bool, 
 		redraw()
 
 		ev := t.Scr.PollEvent()
+		if ev == nil {
+			continue
+		}
 
 		switch ev := ev.(type) {
 		case *tcell.EventResize:


### PR DESCRIPTION
The program re-renders the window even when no meaningful events are triggered. This made debugging harder and possibly had performance implications (none that I, as a user, can notice). I might look into this second point later.