### PR TITLE
Added catppuccin-mocha theme 

### DIFF
--- a/themes/catppuccin-mocha
+++ b/themes/catppuccin-mocha
@@ -1,0 +1,6 @@
+bgcol: #1e1e2e
+fgcol: #cdd6f4
+hicol: #a6e3a1
+hicol2: #f2cdcd
+hicol3: #fab387
+errcol: #f38ba8


### PR DESCRIPTION
Added a theme for catppuccin mocha.

Used Colors
bgcol = Base
fgcol = Text
hical = Green
hical2 = Rosewater
hical3 = Peach
errorcol = Red

Link to the theme: https://github.com/catppuccin/catppuccin