### PR TITLE
Windows compatibility

### DIFF
--- a/src/db.go
+++ b/src/db.go
@@ -16,7 +16,9 @@ func init() {
 	var home string
 
 	if home, ok = os.LookupEnv("HOME"); !ok {
-		die("Could not resolve home directory.")
+		if home, ok = os.LookupEnv("USERPROFILE"); !ok {
+			die("Could not resolve home directory.")
+		}
 	}
 
 	if data, ok = os.LookupEnv("XDG_DATA_HOME"); ok {

--- a/src/util.go
+++ b/src/util.go
@@ -218,5 +218,5 @@ func readResource(typ, name string) []byte {
 		}
 	}
 
-	return readPackedFile(filepath.Join(typ, name))
+	return readPackedFile(typ + "/" + name)
 }


### PR DESCRIPTION
When I tried to compile `tt` on Windows, I faced the following bugs.

1. The word list was not found, because the `path` passed to `readPackedFile` was formatted as `words\1000en` instead of `words/1000en`. This is problematic since the `packedFiles` map has hard-coded keys in the `words/1000en` format. To fix this bug, I replaced the call to `filepath.Join` with a hard-coded `/`.
2. The home directory was not found because the `HOME` environment variable is not defined on Windows. I was able to define `$env:HOME = $env:USERPROFILE` and use `tt` successfully, so I updated the program to perform this substitution when the `HOME` environment variable is not defined.

These two changes make `tt` at least minimally usable on Windows!