### PR TITLE
Add support for the XDG Base Directory Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ See `-help` for an exhaustive list of options.
 
 ## Configuration
 
-Custom themes and word lists can be defined in `~/.tt/themes` and `~/.tt/words`
+Custom themes and word lists can be defined in `~/.config/tt/themes` and `~/.config/tt/words`
+(or `~/.tt/themes` and `~/.tt/words`, if no `tt` directory exists in `XDG_CONFIG_HOME`)
 and used in conjunction with the `-theme` and `-words` flags. A list of
 preloaded themes and word lists can be found in `words/` and `themes/` and are
 accessible by default using the respective flags.

--- a/man.md
+++ b/man.md
@@ -195,6 +195,10 @@ Modify to taste.
   not exist, the following directories are searched for a file with the given
   name before falling back to internal resources:
 
+  ${XDG_CONFIG_HOME}/tt/words\
+  ${XDG_CONFIG_HOME}/tt/themes\
+  ~/.config/tt/words\
+  ~/.config/tt/themes\
   ~/.tt/words\
   ~/.tt/themes\
   /etc/tt/words\

--- a/src/util.go
+++ b/src/util.go
@@ -18,7 +18,13 @@ var CONFIG_DIRS []string
 func init() {
 	home, _ := os.LookupEnv("HOME")
 
+	configDir, isConfigSet := os.LookupEnv("XDG_CONFIG_HOME")
+	if !isConfigSet {
+		configDir = filepath.Join(home, ".config")
+	}
+
 	CONFIG_DIRS = []string{
+		filepath.Join(configDir, "tt"),
 		filepath.Join(home, ".tt"),
 		"/etc/tt",
 	}


### PR DESCRIPTION
This adds the `XDG_CONFIG_HOME` directory to the `CONFIG_DIRS`, allowing the `~/.tt/*` directory structure to be moved to `~/.config/tt/*`.

See also: https://specifications.freedesktop.org/basedir-spec/latest